### PR TITLE
[models] Fix SortFilterModel

### DIFF
--- a/src/lib/sortfiltermodel.h
+++ b/src/lib/sortfiltermodel.h
@@ -18,7 +18,7 @@
  * @class SortFilterModel
  * @short Filter and sort an existing QAbstractItemModel
  */
-class SortFilterModel : public QSortFilterProxyModel
+class Q_DECL_EXPORT SortFilterModel : public QSortFilterProxyModel
 {
     Q_OBJECT
     /**


### PR DESCRIPTION
Fixes error `libnemomodels.so: undefined symbol: _ZTI15SortFilterModel`