### PR TITLE
fix some deprecated types to be able compile with Qt6

### DIFF
--- a/src/lib/filtermodel.cpp
+++ b/src/lib/filtermodel.cpp
@@ -34,6 +34,7 @@
 #include "filtermodel.h"
 
 #include <QRegularExpression>
+#include <QSequentialIterable>
 #include <QtDebug>
 
 namespace {

--- a/src/lib/searchmodel.cpp
+++ b/src/lib/searchmodel.cpp
@@ -32,6 +32,7 @@
 
 #include "searchmodel.h"
 
+#include <QSequentialIterable>
 #include <MLocale>
 #include <MBreakIterator>
 
@@ -75,7 +76,7 @@ QMap<uint, QString> decompositionMapping()
 
 QStringList tokenize(const QString &word)
 {
-    static const QSet<QString> alphabet(mLocale.exemplarCharactersIndex().toSet());
+    static const QSet<QString> alphabet(mLocale.exemplarCharactersIndex().begin(), mLocale.exemplarCharactersIndex().end());
     static const QMap<uint, QString> decompositions(decompositionMapping());
 
     // Convert the word to canonical form

--- a/src/lib/searchmodel.cpp
+++ b/src/lib/searchmodel.cpp
@@ -76,7 +76,13 @@ QMap<uint, QString> decompositionMapping()
 
 QStringList tokenize(const QString &word)
 {
+
+#if QT_VERSION < 0x051500
+    static const QSet<QString> alphabet(mLocale.exemplarCharactersIndex().toSet());
+#else
     static const QSet<QString> alphabet(mLocale.exemplarCharactersIndex().begin(), mLocale.exemplarCharactersIndex().end());
+#endif
+
     static const QMap<uint, QString> decompositions(decompositionMapping());
 
     // Convert the word to canonical form

--- a/src/lib/sortfiltermodel.cpp
+++ b/src/lib/sortfiltermodel.cpp
@@ -99,13 +99,13 @@ void SortFilterModel::setFilterRegExp(const QString &exp)
     if (exp == filterRegExp()) {
         return;
     }
-    QSortFilterProxyModel::setFilterRegExp(QRegExp(exp, Qt::CaseInsensitive));
+    QSortFilterProxyModel::setFilterRegularExpression(QRegularExpression(exp, QRegularExpression::CaseInsensitiveOption));
     Q_EMIT filterRegExpChanged(exp);
 }
 
 QString SortFilterModel::filterRegExp() const
 {
-    return QSortFilterProxyModel::filterRegExp().pattern();
+    return QSortFilterProxyModel::filterRegularExpression().pattern();
 }
 
 void SortFilterModel::setFilterString(const QString &filterString)

--- a/src/lib/sortfiltermodel.cpp
+++ b/src/lib/sortfiltermodel.cpp
@@ -99,13 +99,24 @@ void SortFilterModel::setFilterRegExp(const QString &exp)
     if (exp == filterRegExp()) {
         return;
     }
+
+#if QT_VERSION < 0x051500
+    QSortFilterProxyModel::setFilterRegExp(QRegExp(exp, Qt::CaseInsensitive));
+#else
     QSortFilterProxyModel::setFilterRegularExpression(QRegularExpression(exp, QRegularExpression::CaseInsensitiveOption));
+#endif
     Q_EMIT filterRegExpChanged(exp);
 }
 
 QString SortFilterModel::filterRegExp() const
 {
+
+#if QT_VERSION < 0x051500
+    return QSortFilterProxyModel::filterRegExp().pattern();
+#else
     return QSortFilterProxyModel::filterRegularExpression().pattern();
+#endif
+
 }
 
 void SortFilterModel::setFilterString(const QString &filterString)


### PR DESCRIPTION
QList<QString> to QSet<QString> is now done via constructor instead of .toSet() QRegExp is replaced by QRegularExpression